### PR TITLE
Fix properties file loading

### DIFF
--- a/OrionLauncher/src/main/java/eu/mikroskeem/orion/launcher/Bootstrap.java
+++ b/OrionLauncher/src/main/java/eu/mikroskeem/orion/launcher/Bootstrap.java
@@ -68,7 +68,7 @@ public final class Bootstrap {
     private final static Properties orionProperties = new Properties();
 
     static {
-        Path propertiesPath = Paths.get(System.getProperty("orion.propertiesPath"), "./orion.properties");
+        Path propertiesPath = Paths.get(System.getProperty("orion.propertiesPath", "./orion.properties"));
         if(Files.exists(propertiesPath) && Files.isRegularFile(propertiesPath)) {
             try {
                 orionProperties.load(Files.newBufferedReader(propertiesPath));


### PR DESCRIPTION
The value of the `propertiesPath` variable looked like `null/./orion.properties`, which was the wrong path to the properties file.